### PR TITLE
add missing event parameter to touchEndEvent

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ var vueTouchEvents = {
                 $this.touchStarted = $this.touchMoved = false
                 $this.startX = $this.startY = 0
             },
-            touchEndEvent = function () {
+            touchEndEvent = function (event) {
                 var $this = this.$$touchObj
 
                 $this.touchStarted = false


### PR DESCRIPTION
This fixes a `ReferenceError: event is not defined` error I was hitting.