### PR TITLE
Fix problem where swipeTolerance didn't do anything

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ var vueTouchEvents = {
             } else if (!$this.swipeOutBounded) {
                 var swipeOutBounded = options.swipeTolerance
 
-                $this.swipeOutBounded = Math.abs($this.startX - $this.currentX) > swipeOutBounded &&
-                    Math.abs($this.startY - $this.currentY) > swipeOutBounded
+                $this.swipeOutBounded = Math.abs($this.startX - $this.currentX) > swipeOutBounded ||
+                                        Math.abs($this.startY - $this.currentY) > swipeOutBounded
             }
         }
 
@@ -111,7 +111,7 @@ var vueTouchEvents = {
                     triggerEvent(event, this, 'tap')
                 }
 
-            } else if (!$this.swipeOutBounded) {
+            } else if ($this.swipeOutBounded) {
                 var swipeOutBounded = options.swipeTolerance, direction
 
                 if (Math.abs($this.startX - $this.currentX) < swipeOutBounded) {


### PR DESCRIPTION
I have been having trouble with the `swipeTolerance` property. When set in my own `main.js`, it properly applied to the `options` object in this `index.js`. However, the event *always* fired regardless of whether the value was `30` or `30000`. 

The way I understand the tolerance to work is that it is a minimum number of pixels that must be moved before the event fires. For instance, if a user moves their finger on the screen slightly, the swipe event is _not_ triggered. But if they move it a greater distance, then the event _is_ triggered. At least that is the way I need it to be. (If that is not the expectation here, than this PR will not be right).

There was another problem: the user must move in both the X and Y axis in order for the `swipeOutBounded` to be true. This meant that only diagonal movements would work. The logic seemed backwards on the original `$this.swipeOutBounded` condition because it would always fire an event so long as the swipe was not a large X and Y swipe. 

This fixes these problems. The end result is that if a user swipes either on the X or Y axis for a distance _greater than_ the `swipeTolerance` the event will trigger. If a shorter swipe, nothing will happen. I am happy to clarify if you have any questions.