### PR TITLE
removed the specific mouse event handling functions ..

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ In your `.vue` file:
 <!-- bind a start and end event -->
 <span v-touch:start="startHandler" v-touch:end="endHandler">Down,start/Up,end Event</span>
 
+<!-- bind a move and moving event -->
+<span v-touch:moved="movedHandler">Triggered once when starting to move and tapTolerance is exceeded</span>
+<span v-touch:moving="movingHandler">Continuously triggering Event</span>
+
+
 <!-- you can even mix multiple events -->
 <span v-touch:tap="tapHandler"
     v-touch:longtap="longtapHandler"

--- a/index.js
+++ b/index.js
@@ -106,9 +106,9 @@ var vueTouchEvents = {
                     Math.abs($this.startY - $this.currentY) > swipeOutBounded
             }
 
-			if($this.touchMoved){
+            if($this.touchMoved){
                 triggerEvent(event, this, 'moving')
-			}
+            }
         }
 
         function touchCancelEvent() {

--- a/index.js
+++ b/index.js
@@ -5,10 +5,16 @@
  */
 
 function touchX(event) {
+    if(event.type.indexOf("mouse") !== -1){
+        return event.clientX;
+    }
     return event.touches[0].clientX;
 }
 
 function touchY(event) {
+	if(event.type.indexOf("mouse") !== -1){
+		return event.clientY;
+	}
     return event.touches[0].clientY;
 }
 
@@ -41,8 +47,14 @@ var vueTouchEvents = {
 
         function touchStartEvent(event) {
             var $this = this.$$touchObj
+			if(event.type.indexOf("mouse") === -1){
+                $this.supportTouch = true;
+			}
 
-            $this.supportTouch = true
+			if($this.supportTouch && event.type.indexOf("mouse") !== -1){
+				// don't click when we're touch instead of clicking
+				return;
+			}
 
             if ($this.touchStarted) {
                 return
@@ -63,11 +75,16 @@ var vueTouchEvents = {
 
             $this.touchStartTime = event.timeStamp
 
-            triggerEvent(event, this, 'start')
+			triggerEvent(event, this, 'start')
         }
 
         function touchMoveEvent(event) {
             var $this = this.$$touchObj
+
+			if($this.supportTouch && event.type.indexOf("mouse") !== -1){
+				// don't move when we're touch instead of clicking
+				return;
+			}
 
             $this.currentX = touchX(event)
             $this.currentY = touchY(event)
@@ -106,6 +123,11 @@ var vueTouchEvents = {
         function touchEndEvent(event) {
             var $this = this.$$touchObj
 
+			if($this.supportTouch && event.type.indexOf("mouse") !== -1){
+				// don't touchend when we're touch instead of clicking
+				return;
+			}
+
             $this.touchStarted = false
 
             removeTouchClass(this)
@@ -141,30 +163,6 @@ var vueTouchEvents = {
                     triggerEvent(event, this, 'swipe', direction)
                 }
             }
-        }
-
-        function clickEvent(event) {
-            var $this = this.$$touchObj
-
-            if (!$this.supportTouch && !options.disableClick) {
-                triggerEvent(event, this, 'tap')
-            }
-        }
-
-        function mouseDownEvent(event) {
-        	var $this = this.$$touchObj
-
-			if (!$this.supportTouch && !options.disableClick) {
-                triggerEvent(event, this, 'start')
-			}
-        }
-
-        function mouseUpEvent(event) {
-            var $this = this.$$touchObj
-
-			if (!$this.supportTouch && !options.disableClick) {
-                triggerEvent(event, this, 'end')
-			}
         }
 
         function mouseEnterEvent() {
@@ -270,9 +268,10 @@ var vueTouchEvents = {
                 $el.addEventListener('touchend', touchEndEvent)
 
                 if (!options.disableClick) {
-                    $el.addEventListener('click', clickEvent)
-                    $el.addEventListener('mousedown', mouseDownEvent)
-                    $el.addEventListener('mouseup', mouseUpEvent)
+                    //$el.addEventListener('click', clickEvent)
+					$el.addEventListener('mousedown', touchStartEvent)
+					$el.addEventListener('mousemove', touchMoveEvent)
+                    $el.addEventListener('mouseup', touchEndEvent)
                     $el.addEventListener('mouseenter', mouseEnterEvent)
                     $el.addEventListener('mouseleave', mouseLeaveEvent)
                 }
@@ -288,9 +287,10 @@ var vueTouchEvents = {
                 $el.removeEventListener('touchend', touchEndEvent)
 
                 if (!options.disableClick) {
-                    $el.removeEventListener('click', clickEvent)
-                    $el.removeEventListener('mousedown', mouseDownEvent)
-                    $el.removeEventListener('mouseup', mouseUpEvent)
+                    //$el.removeEventListener('click', clickEvent)
+                    $el.removeEventListener('mousedown', touchStartEvent)
+					$el.removeEventListener('mousemove', touchMoveEvent)
+                    $el.removeEventListener('mouseup', touchEndEvent)
                     $el.removeEventListener('mouseenter', mouseEnterEvent)
                     $el.removeEventListener('mouseleave', mouseLeaveEvent)
                 }

--- a/index.js
+++ b/index.js
@@ -78,12 +78,20 @@ var vueTouchEvents = {
                 $this.touchMoved = Math.abs($this.startX - $this.currentX) > tapTolerance ||
                     Math.abs($this.startY - $this.currentY) > tapTolerance
 
+                if($this.touchMoved){
+					triggerEvent(event, this, 'moved')
+                }
+
             } else if (!$this.swipeOutBounded) {
                 var swipeOutBounded = options.swipeTolerance
 
                 $this.swipeOutBounded = Math.abs($this.startX - $this.currentX) > swipeOutBounded &&
                     Math.abs($this.startY - $this.currentY) > swipeOutBounded
             }
+
+			if($this.touchMoved){
+				triggerEvent(event, this, 'moving')
+			}
         }
 
         function touchCancelEvent() {

--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ function touchX(event) {
 }
 
 function touchY(event) {
-	if(event.type.indexOf("mouse") !== -1){
-		return event.clientY;
-	}
+    if(event.type.indexOf("mouse") !== -1){
+        return event.clientY;
+    }
     return event.touches[0].clientY;
 }
 
@@ -47,14 +47,14 @@ var vueTouchEvents = {
 
         function touchStartEvent(event) {
             var $this = this.$$touchObj
-			if(event.type.indexOf("mouse") === -1){
+            if(event.type.indexOf("mouse") === -1){
                 $this.supportTouch = true;
-			}
+            }
 
-			if($this.supportTouch && event.type.indexOf("mouse") !== -1){
-				// don't click when we're touch instead of clicking
-				return;
-			}
+            if($this.supportTouch && event.type.indexOf("mouse") !== -1){
+                // don't click when we're touch instead of clicking
+                return;
+            }
 
             if ($this.touchStarted) {
                 return
@@ -75,16 +75,16 @@ var vueTouchEvents = {
 
             $this.touchStartTime = event.timeStamp
 
-			triggerEvent(event, this, 'start')
+            triggerEvent(event, this, 'start')
         }
 
         function touchMoveEvent(event) {
             var $this = this.$$touchObj
 
-			if($this.supportTouch && event.type.indexOf("mouse") !== -1){
-				// don't move when we're touch instead of clicking
-				return;
-			}
+            if($this.supportTouch && event.type.indexOf("mouse") !== -1){
+                // don't move when we're touch instead of clicking
+                return;
+            }
 
             $this.currentX = touchX(event)
             $this.currentY = touchY(event)
@@ -96,7 +96,7 @@ var vueTouchEvents = {
                     Math.abs($this.startY - $this.currentY) > tapTolerance
 
                 if($this.touchMoved){
-					triggerEvent(event, this, 'moved')
+                    triggerEvent(event, this, 'moved')
                 }
 
             } else if (!$this.swipeOutBounded) {
@@ -107,7 +107,7 @@ var vueTouchEvents = {
             }
 
 			if($this.touchMoved){
-				triggerEvent(event, this, 'moving')
+                triggerEvent(event, this, 'moving')
 			}
         }
 
@@ -123,10 +123,10 @@ var vueTouchEvents = {
         function touchEndEvent(event) {
             var $this = this.$$touchObj
 
-			if($this.supportTouch && event.type.indexOf("mouse") !== -1){
-				// don't touchend when we're touch instead of clicking
-				return;
-			}
+            if($this.supportTouch && event.type.indexOf("mouse") !== -1){
+                // don't touchend when we're touch instead of clicking
+                return;
+            }
 
             $this.touchStarted = false
 
@@ -269,8 +269,8 @@ var vueTouchEvents = {
 
                 if (!options.disableClick) {
                     //$el.addEventListener('click', clickEvent)
-					$el.addEventListener('mousedown', touchStartEvent)
-					$el.addEventListener('mousemove', touchMoveEvent)
+                    $el.addEventListener('mousedown', touchStartEvent)
+                    $el.addEventListener('mousemove', touchMoveEvent)
                     $el.addEventListener('mouseup', touchEndEvent)
                     $el.addEventListener('mouseenter', mouseEnterEvent)
                     $el.addEventListener('mouseleave', mouseLeaveEvent)
@@ -289,7 +289,7 @@ var vueTouchEvents = {
                 if (!options.disableClick) {
                     //$el.removeEventListener('click', clickEvent)
                     $el.removeEventListener('mousedown', touchStartEvent)
-					$el.removeEventListener('mousemove', touchMoveEvent)
+                    $el.removeEventListener('mousemove', touchMoveEvent)
                     $el.removeEventListener('mouseup', touchEndEvent)
                     $el.removeEventListener('mouseenter', mouseEnterEvent)
                     $el.removeEventListener('mouseleave', mouseLeaveEvent)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-touch-events",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Simple touch events support for vueJS2",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Removed the specific mouse event handling functions in favor of the existing ones for touch. 
touchX en touchY methods now handle returning the correct position.

The only cullprit i can see is if you're using hot reloading and switch from mobile to desktop view in chrome. the click events won't work until you reload the page. (supportTouch is never set to false)

The advantage is that swipe and all other functions are equally supported on non-touch devices.