### PR TITLE
Alternative directive name

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ For example:
 
 Now, when you start to touch, it will add an extra `active` class automatically. And remove it when touch end.
 
-If your setting of `disableClick` is `false` (it's default), it will bind `mouseenter` and `mouseleave` events, too.
-
 So that you can use this feature to instead of `:active` and `:hover` pseudo class, for a better user experience.
 
 ```css

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import {PluginObject} from "vue";
 declare const Vue2TouchEvents: PluginObject<Vue2TouchEventsOptions>;
 
 export interface Vue2TouchEventsOptions {
+  directiveName?: string;
   touchClass?: string;
   tapTolerance?: number;
   swipeTolerance?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,6 @@ import {PluginObject} from "vue";
 declare const Vue2TouchEvents: PluginObject<Vue2TouchEventsOptions>;
 
 export interface Vue2TouchEventsOptions {
-  disableClick?: boolean;
   touchClass?: string;
   tapTolerance?: number;
   swipeTolerance?: number;

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ var vueTouchEvents = {
 
         // Set default options
         options = Object.assign({}, {
+            directiveName: 'touch',
             tapTolerance: 10,
             swipeTolerance: 30,
             longTapTimeInterval: 400,
@@ -221,7 +222,7 @@ var vueTouchEvents = {
             className && $el.classList.remove(className)
         }
 
-        Vue.directive('touch', {
+        Vue.directive(options.directiveName, {
             bind: function ($el, binding) {
 
                 $el.$$touchObj = $el.$$touchObj || {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ var vueTouchEvents = {
 
         // Set default options
         options = Object.assign({}, {
-            disableClick: false,
             tapTolerance: 10,
             swipeTolerance: 30,
             longTapTimeInterval: 400,


### PR DESCRIPTION
* Removes leftover `disableClick` code and docs
* Supports the client application using a directive name other than `v-touch` if desired