### PR TITLE
Support updating touch event handler on reused cached components

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,8 +273,8 @@ var vueTouchEvents = {
                 delete $el.$$touchObj;
         };
         Vue.directive('touch', {
-            componentUpdated: function ($el) {
-                removePreviousEventListeners($el, binding);
+            componentUpdated: function ($el, binding) {
+                removePreviousEventListeners($el);
                 // build a touch configuration object
                 var $this = buildTouchObj($el);
 

--- a/index.js
+++ b/index.js
@@ -272,10 +272,8 @@ var vueTouchEvents = {
                 // remove vars
                 delete $el.$$touchObj;
         };
-        Vue.directive('touch', {
-            componentUpdated: function ($el, binding) {
-                removePreviousEventListeners($el);
-                // build a touch configuration object
+        function bindNewEventListeners($el, binding) {
+             // build a touch configuration object
                 var $this = buildTouchObj($el);
 
                 // register callback
@@ -323,6 +321,14 @@ var vueTouchEvents = {
 
                 // set bind mark to true
                 $this.hasBindTouchEvents = true;
+        };
+        Vue.directive('touch', {
+            bind: function($el, binding) {
+                bindNewEventListeners($el, binding);
+            },
+            componentUpdated: function ($el, binding) {
+                removePreviousEventListeners($el);
+                bindNewEventListeners($el, binding);
             },
 
             unbind: function ($el) {

--- a/index.js
+++ b/index.js
@@ -255,9 +255,26 @@ var vueTouchEvents = {
             $el.$$touchObj = touchObj;
             return $el.$$touchObj;
         }
+        function removePreviousEventListeners($el) {
+                $el.removeEventListener('touchstart', touchStartEvent);
+                $el.removeEventListener('touchmove', touchMoveEvent);
+                $el.removeEventListener('touchcancel', touchCancelEvent);
+                $el.removeEventListener('touchend', touchEndEvent);
 
+                if ($el.$$touchObj && !$el.$$touchObj.options.disableClick) {
+                    $el.removeEventListener('mousedown', touchStartEvent);
+                    $el.removeEventListener('mousemove', touchMoveEvent);
+                    $el.removeEventListener('mouseup', touchEndEvent);
+                    $el.removeEventListener('mouseenter', mouseEnterEvent);
+                    $el.removeEventListener('mouseleave', mouseLeaveEvent);
+                }
+
+                // remove vars
+                delete $el.$$touchObj;
+        };
         Vue.directive('touch', {
-            bind: function ($el, binding) {
+            componentUpdated: function ($el) {
+                removePreviousEventListeners($el, binding);
                 // build a touch configuration object
                 var $this = buildTouchObj($el);
 
@@ -309,21 +326,7 @@ var vueTouchEvents = {
             },
 
             unbind: function ($el) {
-                $el.removeEventListener('touchstart', touchStartEvent);
-                $el.removeEventListener('touchmove', touchMoveEvent);
-                $el.removeEventListener('touchcancel', touchCancelEvent);
-                $el.removeEventListener('touchend', touchEndEvent);
-
-                if ($el.$$touchObj && !$el.$$touchObj.options.disableClick) {
-                    $el.removeEventListener('mousedown', touchStartEvent);
-                    $el.removeEventListener('mousemove', touchMoveEvent);
-                    $el.removeEventListener('mouseup', touchEndEvent);
-                    $el.removeEventListener('mouseenter', mouseEnterEvent);
-                    $el.removeEventListener('mouseleave', mouseLeaveEvent);
-                }
-
-                // remove vars
-                delete $el.$$touchObj;
+                removePreviousEventListeners($el);
             }
         });
 


### PR DESCRIPTION
With current directive installation scheme, a tap listener would not update when a cached component is reused, e.g. when [this documented hack](https://www.npmjs.com/package/vue2-touch-events#how-to-add-extra-parameters) is used. An example to consider:

```html
<HeroPortrait
    v-for="hero in heroes"
    v-touch:tap="onPortraitTapHacky(hero)"
/>
```
```js
export default {
  props: {
    heroes: {
      type: Array
    }
  }
  methods: {
    onPortraitTapHacky(hero) {
        return function() {
            alert(hero.name)
        };
    },
  }
}
```
Without the fix, when `heroes` prop is changed and the list of portraits is rebuilt, a cached component is used for each updated portrait, and on that cached component the event handler would not correspond to the current hero bound to that component.

I'm not very experienced with vue.js, so please suggest code improvements.