### PR TITLE
Add disablePassive modifier for start and moving events

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,6 +280,15 @@ var vueTouchEvents = {
                             $this.callbacks.swipe.push(binding);
                         }
                         break;
+                    
+                    case 'start':
+                        var _m = binding.modifiers;
+                        if (_m.disablePassive) {
+                            // change the passive option for the moving event if disablePassive modifier exists
+                            passiveOpt = false;
+                        }
+                        break;
+    
 
                     case 'moving':
                         var _m = binding.modifiers;
@@ -287,6 +296,7 @@ var vueTouchEvents = {
                             // change the passive option for the moving event if disablePassive modifier exists
                             passiveOpt = false;
                         }
+                        break;
 
                     default:
                         $this.callbacks[eventType] = $this.callbacks[eventType] || [];

--- a/index.js
+++ b/index.js
@@ -260,7 +260,8 @@ var vueTouchEvents = {
             bind: function ($el, binding) {
                 // build a touch configuration object
                 var $this = buildTouchObj($el);
-
+                // declare passive option for the event listener. Defaults to { passive: true } if supported
+                var passiveOpt = isPassiveSupported ? { passive: true } : false;
                 // register callback
                 var eventType = binding.arg || 'tap';
                 switch (eventType) {
@@ -280,6 +281,13 @@ var vueTouchEvents = {
                         }
                         break;
 
+                    case 'moving':
+                        var _m = binding.modifiers;
+                        if (_m.disablePassive) {
+                            // change the passive option for the moving event if disablePassive modifier exists
+                            passiveOpt = false;
+                        }
+
                     default:
                         $this.callbacks[eventType] = $this.callbacks[eventType] || [];
                         $this.callbacks[eventType].push(binding);
@@ -290,7 +298,6 @@ var vueTouchEvents = {
                     return;
                 }
 
-                var passiveOpt = isPassiveSupported ? { passive: true } : false;
                 $el.addEventListener('touchstart', touchStartEvent, passiveOpt);
                 $el.addEventListener('touchmove', touchMoveEvent, passiveOpt);
                 $el.addEventListener('touchcancel', touchCancelEvent);


### PR DESCRIPTION
Allows use of a modifier in the `v-touch` directive for `start` and `moving `events to send the option `{ passive: false }` on event listener creation.

Example in template:
`<div v-touch:moving.disablePassive="movingHandler" > </div>`

Example in script:
`methods: { movingHandler (event) { event.preventDefault() } }`

preventDefault() works when disablePassive modifier is used as specified in event listener options: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
