### PR TITLE
Fix start and moving events

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,22 +282,11 @@ var vueTouchEvents = {
                         break;
                     
                     case 'start':
-                        var _m = binding.modifiers;
-                        if (_m.disablePassive) {
-                            // change the passive option for the moving event if disablePassive modifier exists
-                            passiveOpt = false;
-                        }
-                        break;
-    
-
                     case 'moving':
-                        var _m = binding.modifiers;
-                        if (_m.disablePassive) {
+                        if (binding.modifiers.disablePassive) {
                             // change the passive option for the moving event if disablePassive modifier exists
                             passiveOpt = false;
                         }
-                        break;
-
                     default:
                         $this.callbacks[eventType] = $this.callbacks[eventType] || [];
                         $this.callbacks[eventType].push(binding);


### PR DESCRIPTION
the `break` statement needs to be removed in the moving case so that the default case can fire the start and moving events